### PR TITLE
Updated question mark syntax in urban dictionary plugin.

### DIFF
--- a/plugins/urban_dict.rb
+++ b/plugins/urban_dict.rb
@@ -6,7 +6,7 @@ require 'cgi'
 class Dictionary
   include Cinch::Plugin
 
-  match(/^(.+)\?\s*$/i, method: :urban_dict, use_prefix: false)
+  match(/^(.+)\??\s*$/i, method: :urban_dict, use_prefix: false)
   match(/^\.u (.+)/i, method: :urban_dict, use_prefix: false)
   def urban_dict(m, query)
     url        = "http://www.urbandictionary.com/define.php?term=#{CGI.escape(query)}"


### PR DESCRIPTION
This should prevent Rubee from trying to respond to any random sentence ending in a question mark. It also ensures the only ways to interact with the urban dictionary plugin are using the more explicit .u and ?? commands,  preventing accidental lookups of a definition.